### PR TITLE
Mm print depth

### DIFF
--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -147,6 +147,7 @@ pub struct CircuitBuilder<F: RichField + Extendable<D>, const D: usize> {
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn new(config: CircuitConfig) -> Self {
+        println!("{D}");
         let builder = CircuitBuilder {
             config,
             domain_separator: None,


### PR DESCRIPTION
Prints out the circuit depth when new() is run in circuit builder.

*Will print out multiple times for recursion.