### PR TITLE
Mm print config

### DIFF
--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -147,6 +147,7 @@ pub struct CircuitBuilder<F: RichField + Extendable<D>, const D: usize> {
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn new(config: CircuitConfig) -> Self {
+        println!("{D}");
         let builder = CircuitBuilder {
             config,
             domain_separator: None,

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -147,7 +147,9 @@ pub struct CircuitBuilder<F: RichField + Extendable<D>, const D: usize> {
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn new(config: CircuitConfig) -> Self {
-        println!("{D}");
+        println!("Circuit Depth: {D}");
+        println!("num_wires: {}", config.num_wires);
+        println!("num_routed_wires: {}", config.num_routed_wires);
         let builder = CircuitBuilder {
             config,
             domain_separator: None,


### PR DESCRIPTION
Prints out num_wires and num_routed_wires. 

Example output running square_root.rs:
Circuit Depth: 2
num_wires: 135
num_routed_wires: 80
Square root: 15886081286298290786
Field element (square): 2768993568539203298